### PR TITLE
delete line that throws on a nick change.

### DIFF
--- a/scripts/hubot-logger.coffee
+++ b/scripts/hubot-logger.coffee
@@ -127,7 +127,6 @@ module.exports = (robot) ->
         log_message(logs_root, new Tempus(), "action", to, {nick: nick, action: result[1], raw: message })
     
     robot.adapter.bot.on 'nick', (oldnick, newnick, channels, message) ->
-      result = (text + '').match(/^\x01ACTION (.*)\x01$/)
       for channel in channels
         log_message(logs_root, new Tempus(), "nick", channel, {nick: oldnick, new_nick: newnick })
         


### PR DESCRIPTION
I believe this line was inadvertently copied from the previous function.  There is no text variable, so if someone changes their nick, hubot-logger throws an exception and the bot quits.
